### PR TITLE
nodecontainer layed out with some functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate conrod;
 extern crate elmesque;
+extern crate opengl_graphics;
 
 pub use toolpane::{ToolPane};
 pub use graph::{graphs};
@@ -7,3 +8,65 @@ pub use graph::{graphs};
 pub mod toolpane;
 pub mod node;
 pub mod graph;
+
+
+use conrod::{Ui,Label,Button,Positionable,Sizeable};
+use opengl_graphics::glyph_cache::GlyphCache;
+// we have to track actions outside of a conrod widget, from what I understand, for us to manipulate widget to widget
+// hence the nodecontainer, which lays out the node object visually, and controls its appearance
+pub struct NodeContainer {
+    xy: [f64;2],
+    drag: bool,
+    collapse: bool,
+    destroy: bool,
+    sidx: usize, //start index
+}
+
+impl NodeContainer {
+    pub fn new(idx: usize, xy:[f64;2]) -> NodeContainer {
+        NodeContainer {
+            xy: xy,
+            drag: false,
+            collapse: false,
+            destroy: false,
+            // we need a starting index so conrod is happy, it'd make more sense if conrod returned an index when creating the widgets; instead we'll track manually
+            sidx: idx,
+        }
+    }
+    pub fn draw(&mut self, ui: &mut Ui<GlyphCache>) {
+        // todo: update graph if we destroy node
+        if self.destroy { return } // probably should do a real drop!
+        
+        let idx = self.sidx;
+        Button::new() //this should be a press-action, not a release; fixme with custom widget! also conrod should have a drag controller widget, which is basically what we're building
+            .xy(self.xy[0], self.xy[1])
+            .dimensions(100.0,20.0)
+            .react(|| { self.drag = !self.drag; })
+            .set(idx,ui);
+
+        Button::new()
+            .right(5.0)
+            .dimensions(20.0,20.0)
+            .react(|| { self.collapse = !self.collapse; })
+            .set(idx+1,ui);
+
+        Button::new()
+            .right(5.0)
+            .dimensions(20.0,20.0)
+            .react(|| { self.destroy=true; })
+            .set(idx+2,ui);
+
+        if !self.collapse {
+            Label::new(&idx.to_string())
+                .down_from(idx, 5.0)
+                .set(idx+3,ui);
+        }
+    }
+    
+    pub fn update(&mut self, xy: [f64;2]) {
+        // check for destroy until we formally remove nodecontainer
+        if !self.destroy && self.drag {
+            self.xy = xy;
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 extern crate mush;
 
-use mush::{NodeContainer};
+use mush::{NodeContainer,ToolPane};
 
 extern crate conrod;
 extern crate glutin_window;
@@ -15,6 +15,9 @@ use opengl_graphics::glyph_cache::GlyphCache;
 use piston::event::*;
 use piston::window::{ WindowSettings, Size };
 use std::path::Path;
+
+extern crate petgraph;
+use self::petgraph::{Graph};
 
 //fn resized(w:u32,h:u32) {width=w; height=h;}
 
@@ -33,6 +36,8 @@ fn main () {
             .samples(4)
        );
 
+    let mut tools = ToolPane::new(4); //nodecontainer has 4 widgets
+    let mut graph = Graph::new();
     
 
     let event_iter = window.events().ups(180).max_fps(60);
@@ -41,9 +46,8 @@ fn main () {
     let theme = Theme::default();
     let glyph_cache = GlyphCache::new(&font_path).unwrap();
     let mut ui = &mut Ui::new(glyph_cache, theme);
+
     
-    let mut cont = NodeContainer::new(0,[120.0,120.0]);
-    let mut cont2 = NodeContainer::new(6,[400.0,200.0]); //for now trakc index manually, so no overlaps. It may be best to use a NodePane controller, which handles this state/count
     
     for event in event_iter {
         ui.handle_event(&event);
@@ -54,11 +58,7 @@ fn main () {
                 // Draw the background.
                 Background::new().rgb(0.2, 0.2, 0.2).draw(ui, gl); //this swaps buffers for us
 
-                cont.update(ui.mouse.xy);
-                cont.draw(&mut ui);
-                
-                cont2.update(ui.mouse.xy);
-                cont2.draw(&mut ui);
+                tools.draw(&mut ui, &mut graph);
                 
                 /* mush::node::Node::new()
                 .label("Thingy")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 extern crate mush;
 
-use mush::{ToolPane};
+use mush::{NodeContainer};
 
 extern crate conrod;
 extern crate glutin_window;
 extern crate opengl_graphics;
 extern crate piston;
 
-use conrod::{Background, Button, Colorable, Labelable, Sizeable, Theme, Ui,
+use conrod::{Background, Button, Toggle , Colorable, Labelable, Sizeable, Theme, Ui,
              Positionable, TextBox, CustomWidget, Position};
 use glutin_window::GlutinWindow;
 use opengl_graphics::{ GlGraphics, OpenGL };
@@ -33,17 +33,18 @@ fn main () {
             .samples(4)
        );
 
-   // window.window.set_window_resize_callback(Some(resized as fn(u32,u32)));
+    
 
     let event_iter = window.events().ups(180).max_fps(60);
     let mut gl = GlGraphics::new(opengl);
     let font_path = Path::new("fonts/SourceCodePro-Regular.otf");
     let theme = Theme::default();
     let glyph_cache = GlyphCache::new(&font_path).unwrap();
-    let ui = &mut Ui::new(glyph_cache, theme);
-
-    let mut count: u32 = 0;
-
+    let mut ui = &mut Ui::new(glyph_cache, theme);
+    
+    let mut cont = NodeContainer::new(0,[120.0,120.0]);
+    let mut cont2 = NodeContainer::new(6,[400.0,200.0]); //for now trakc index manually, so no overlaps. It may be best to use a NodePane controller, which handles this state/count
+    
     for event in event_iter {
         ui.handle_event(&event);
         
@@ -51,18 +52,23 @@ fn main () {
             gl.draw(args.viewport(), |_, gl| {
 
                 // Draw the background.
-                // Background::new().rgb(0.2, 0.2, 0.2).draw(ui, gl);
+                Background::new().rgb(0.2, 0.2, 0.2).draw(ui, gl); //this swaps buffers for us
 
-
-                mush::node::Node::new()
-                    .label("Thingy")
-                    .xy(100.0, 100.0)
-                    .dimensions(100.0, 40.0)
-                    .set(2, ui);
-
+                cont.update(ui.mouse.xy);
+                cont.draw(&mut ui);
+                
+                cont2.update(ui.mouse.xy);
+                cont2.draw(&mut ui);
+                
+                /* mush::node::Node::new()
+                .label("Thingy")
+                .xy(100.0, 100.0)
+                .dimensions(100.0, 40.0)
+                .set(2, ui);*/
+                
                 // Draw our Ui!
                 ui.draw(gl);
-
+                
             });
         }
     }

--- a/src/toolpane.rs
+++ b/src/toolpane.rs
@@ -1,10 +1,41 @@
+extern crate petgraph;
+
+use ::NodeContainer;
+use opengl_graphics::glyph_cache::GlyphCache;
+use conrod::{Ui,Label,Button,Positionable,Sizeable,Labelable};
+use self::petgraph::{Graph};
+
+// todo: consider generalizing nodecontainer to just a container, and use the methods here as well
 pub struct ToolPane {
-    col: u8,
+    noffset: usize, // offset for nodecontainer widgets, depends on widget count
+    nodes: Vec<NodeContainer>,
 }
 
 impl ToolPane {
-    fn new (col: u8) -> ToolPane { ToolPane {col:col} }
-    //fn add(Button<()>,f: FnMut) {
+    pub fn new (offset:usize) -> ToolPane {
+        ToolPane { noffset: offset,
+                   nodes: vec!(),
+        }
+    }
+    
+    pub fn draw(&mut self, ui: &mut Ui<GlyphCache>, graph: &mut Graph<bool,bool>) {
         
-   // }
+        // we should use a canvas to place this appropriately
+        Button::new()
+            .xy(-1.0*ui.win_w/2.0+50.0,ui.win_h/2.0-20.0)
+            .label("New Node")
+            .dimensions(100.0,40.0)
+            .react(|| {
+                let n = graph.add_node(true);
+                let nuid = (self.nodes.len() + 2) * self.noffset;
+                self.nodes.push(NodeContainer::new(nuid,[0.0,0.0],n));
+            })
+            .set(0,ui);
+
+        let xy = ui.mouse.xy;
+        for n in self.nodes.iter_mut() {
+            n.update(xy);
+            n.draw(ui,graph);
+        }
+    }
 }


### PR DESCRIPTION
I am getting the hang of conrod and set up a basic node container which is for visual layout. provides collapse, drag (albeit wrongly), and hide/destroy. this seems redundant to the node widget you made @stjahns, thoughts? I had to comment out the mush::node widget since it seemed incompatible with conrod widgets. I don't see a drag-controller widget for conrod, so we can hopefully make something similar to what we already had working on the mush::node
