### PR TITLE
Added 'Save' button to ToolPane

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -73,9 +73,12 @@ fn main () {
     graph.add_edge(a,b, DemoEdge::default());
     graph.add_edge(b,c, DemoEdge::default());
 
+    println!("{:?}", graph);
+
     // Let ui graph allocate UiIds starting at 100. Not sure if this is a good idea..
     let ui_id_offset = 100;
     let mut tools = ToolPane::new(ui_id_offset, &graph);
+    tools.on_save(|graph| println!("{:?}", graph));
 
     let event_iter = window.events().ups(180).max_fps(60);
     let mut gl = GlGraphics::new(opengl);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -152,7 +152,17 @@ impl<N: EditableNode, E: EditableEdge> UiGraph<N, E> {
 
     /// Export the UiGraph structure to the original source graph format
     pub fn as_source_graph(&self) -> Graph<N, E> {
-        // TODO
-        Graph::new()
+
+        let mut source_graph = Graph::new();
+
+        for node in self.graph.raw_nodes().iter() {
+            source_graph.add_node(node.weight.source_node.clone());
+        }
+
+        for edge in self.graph.raw_edges().iter() {
+            source_graph.add_edge(edge.source(), edge.target(), edge.weight.source_edge.clone());
+        }
+
+        source_graph
     }
 }

--- a/src/toolpane.rs
+++ b/src/toolpane.rs
@@ -6,27 +6,51 @@ use petgraph::Graph;
 
 use graph::{UiGraph, EditableNode, EditableEdge};
 
-pub struct ToolPane<N: EditableNode, E: EditableEdge> {
+pub struct ToolPane<N: EditableNode, E: EditableEdge, F> {
     ui_graph: UiGraph<N, E>,
+    ui_id_offset: UiId,
+    maybe_on_save: Option<F>
 }
 
-impl<N: EditableNode, E: EditableEdge> ToolPane<N, E> {
+impl<N: EditableNode, E: EditableEdge, F: Fn(Graph<N, E>)> ToolPane<N, E, F> {
 
-    pub fn new(offset: UiId, source_graph: &Graph<N, E>) -> ToolPane<N, E> {
+    pub fn new(offset: UiId, source_graph: &Graph<N, E>) -> ToolPane<N, E, F>
+    {
         ToolPane {
-            ui_graph: UiGraph::new(source_graph, offset)
+            ui_graph: UiGraph::new(source_graph, offset + 2),
+            ui_id_offset: offset,
+            maybe_on_save: None,
         }
     }
 
+    pub fn on_save(&mut self, on_save: F) {
+        self.maybe_on_save = Some(on_save);
+    }
+
     pub fn build_ui(&mut self, ui: &mut Ui<GlyphCache>) {
+        let id_offset = self.ui_id_offset;
+
         // we should use a canvas to place this appropriately
         Button::new()
             .xy(-1.0*ui.win_w/2.0+50.0,ui.win_h/2.0-20.0)
+            .label("Save")
+            .dimensions(100.0, 40.0)
+            .react(|| self.save())
+            .set(id_offset, ui);
+
+        Button::new()
+            .xy(-1.0*ui.win_w/2.0+150.0, ui.win_h/2.0-20.0)
             .label("New Node")
-            .dimensions(100.0,40.0)
+            .dimensions(100.0, 40.0)
             .react(|| self.ui_graph.add_node())
-            .set(0,ui);
+            .set(id_offset + 1, ui);
 
         self.ui_graph.build_ui(ui)
+    }
+
+    pub fn save(&self) where F: Fn(Graph<N, E>) {
+        if let Some(ref on_save) = self.maybe_on_save {
+            on_save(self.ui_graph.as_source_graph());
+        }
     }
 }


### PR DESCRIPTION
Hitting 'Save' converts graph back to original form and passes to an 'on_save' closure provided by the user
