### PR TITLE
WIP: Handling widget ID' properly in a dynamic setting

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -63,6 +63,7 @@ impl UiNode for MyNode {
     fn get_ui_mut(&mut self) -> &mut UiBase {&mut self.uibase}
 }
 impl MyNode {
+    #[allow(dead_code)]
     fn new(p: [f64;2], n: String, id: WidgetId) -> MyNode {
         let mut node = MyNode::default();
         node.name = n;
@@ -110,7 +111,7 @@ fn main () {
 
     graph.direct(&a,&b, MyEdge::default());
     graph.direct(&b,&c, MyEdge::default());
-    graph.direct(&a,&c, MyEdge::default());
+    //graph.direct(&a,&c, MyEdge::default());
     
     // Poll events from the window.
     for event in window.ups(60) {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -111,7 +111,7 @@ fn main () {
 
     graph.direct(&a,&b, MyEdge::default());
     graph.direct(&b,&c, MyEdge::default());
-    //graph.direct(&a,&c, MyEdge::default());
+    graph.direct(&a,&c, MyEdge::default());
     
     // Poll events from the window.
     for event in window.ups(60) {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -101,18 +101,17 @@ fn main () {
     };
 
     // Initialize the graph structure
-    let mut graph = Graph::default();
-    let a = graph.add_node(MyNode::new([-200.0, -200.0], "Stuff".to_string(),WidgetId(50)));
-    let b = graph.add_node(MyNode::new([50.0, 100.0], "Things".to_string(),WidgetId(85)));
-    let c = graph.add_node(MyNode::new([100.0, -100.0], "Whatever".to_string(),WidgetId(120)));
+    let mut graph: Graph<MyEdge,MyNode> = Graph::default();
+    let mut tools = ToolPane::new(&mut graph,"Some Project Name".to_string());
+
+    let a = tools.new_node(&mut graph);
+    let b = tools.new_node(&mut graph);
+    let c = tools.new_node(&mut graph);
+
     graph.direct(&a,&b, MyEdge::default());
     graph.direct(&b,&c, MyEdge::default());
-
-    //println!("{:?}", graph);
-
-    let mut tools = ToolPane::new(&mut graph,"Some Project Name".to_string());
-    //tools.on_save(|graph| println!("{:?}", graph));
-
+    graph.direct(&a,&c, MyEdge::default());
+    
     // Poll events from the window.
     for event in window.ups(60) {
         ui.handle_event(&event);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,4 @@ pub mod backend;
 pub mod uigraph;
 
 pub const MAX_NODES: usize = 1000;
-pub const MAX_CONN_OUT: usize = 100;
-pub const MAX_CONN_IN: usize = 100;
+pub const MAX_CONN: usize = 50; // per node

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,7 @@ pub use uigraph::{UiGraph,UiBase,UiNode};
 pub mod toolpane;
 pub mod backend;
 pub mod uigraph;
+
+pub const MAX_NODES: usize = 1000;
+pub const MAX_CONN_OUT: usize = 100;
+pub const MAX_CONN_IN: usize = 100;

--- a/src/toolpane.rs
+++ b/src/toolpane.rs
@@ -13,15 +13,13 @@ pub struct ToolPane {
 }
 
 impl ToolPane {
-
     pub fn new<N:UiNode,G:Backend<Node=N>>(graph: &mut G,name:String) -> ToolPane
     {
-        //let's allocate 10 widget ids per node plus 10 connects
-        let connects = 10;
-        let mut count = 10+connects;
+        //let's allocate n widget ids per node plus n connects
+        let mut count = 0;
         
         graph.with_nodes_mut(|n| {
-            count += 10+connects;
+            count += ::MAX_CONN_OUT+::MAX_CONN_IN;
             n.get_ui_mut().set_id(WidgetId(count)); 
         });
         ToolPane {
@@ -59,14 +57,20 @@ impl ToolPane {
             .label("New Node")
             .w_h(100.0, 40.0)
             .react(|| {
-                let mut n = N::default();
-                self.next_widget_id += 10;
-                n.get_ui_mut().set_id(WidgetId(self.next_widget_id));
-                
-                graph.add_node(n);
+                self.new_node(graph);
             })
             .set(WidgetId(4), ui);
      
+    }
+
+    pub fn new_node<N:UiNode,G:Backend<Node=N>> (&mut self, graph: &mut G)
+                                                -> G::node_id
+    {
+        let mut n = N::default();
+        self.next_widget_id += ::MAX_CONN_OUT+::MAX_CONN_IN;
+        n.get_ui_mut().set_id(WidgetId(self.next_widget_id));
+        
+        graph.add_node(n)
     }
 
   //  pub fn save(&self) where F: Fn(Graph<N, E>) {

--- a/src/toolpane.rs
+++ b/src/toolpane.rs
@@ -19,7 +19,7 @@ impl ToolPane {
         let mut count = 0;
         
         graph.with_nodes_mut(|n| {
-            count += ::MAX_CONN_OUT+::MAX_CONN_IN + 1;
+            count += (::MAX_CONN*3) + 10;
             n.get_ui_mut().set_id(WidgetId(count)); 
         });
         ToolPane {
@@ -67,7 +67,7 @@ impl ToolPane {
                                                 -> G::node_id
     {
         let mut n = N::default();
-        self.next_widget_id += ::MAX_CONN_OUT+::MAX_CONN_IN + 1;
+        self.next_widget_id += (::MAX_CONN*3) + 10;
         n.get_ui_mut().set_id(WidgetId(self.next_widget_id));
         
         graph.add_node(n)

--- a/src/toolpane.rs
+++ b/src/toolpane.rs
@@ -19,7 +19,7 @@ impl ToolPane {
         let mut count = 0;
         
         graph.with_nodes_mut(|n| {
-            count += ::MAX_CONN_OUT+::MAX_CONN_IN;
+            count += ::MAX_CONN_OUT+::MAX_CONN_IN + 1;
             n.get_ui_mut().set_id(WidgetId(count)); 
         });
         ToolPane {
@@ -67,7 +67,7 @@ impl ToolPane {
                                                 -> G::node_id
     {
         let mut n = N::default();
-        self.next_widget_id += ::MAX_CONN_OUT+::MAX_CONN_IN;
+        self.next_widget_id += ::MAX_CONN_OUT+::MAX_CONN_IN + 1;
         n.get_ui_mut().set_id(WidgetId(self.next_widget_id));
         
         graph.add_node(n)

--- a/src/uigraph.rs
+++ b/src/uigraph.rs
@@ -2,6 +2,8 @@ use conrod::{Button,Positionable, Text, Sizeable,Widget,WidgetId,Canvas,Colorabl
 use piston_window::Glyphs;
 use ::{Backend,Graph,GraphNode,GraphEdge,Nid};
 
+use std::collections::HashMap;
+
 pub type Ui = ::conrod::Ui<Glyphs>;
 
 
@@ -109,6 +111,9 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
     fn render(&mut self, ui: &mut Ui) {
         let mut select: (Option<Nid>,Option<Nid>) = (None,None);
         let mut edges: Vec<(Nid,Vec<Nid>)> = vec!();
+
+        // NOTE: this might change when we start tracking connection types
+        let mut sockets_from = HashMap::new(); // track socket connections for layout
         
         self.with_nodes_mut(|n| {
             let is_select = n.get_ui().select;
@@ -139,7 +144,8 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
         let line_id = 2;
         let socket_id_in = 3;
 
-        let socket_offset = 20.; //20px offset
+        let socket_size = 10.;
+        let socket_offset = 3.*socket_size;
         
         // build edges
         // NOTE: these edges represent forward-edges only
@@ -148,8 +154,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
             
-            let id = nui.get_id().0 * 20; //allot 20 spaces per node
-            let id = WidgetId(id + 1000); // place in 1k range
+            let id = nui.get_id().0 * 100; //allotment per node
 
             let mut from_pos = *n.get_position();
             
@@ -160,16 +165,19 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                 from_pos[0] -= nui.width/2.;
                 
                 let k = k + 1;
+
+                let from_count = sockets_from.entry(en).or_insert(0);
+                *from_count += 1; //inc sock count from-connections
                 
                 if let Some(n2) = self.get_node(&en) {
                     let mut to_pos = *n2.get_position();
                     if !n2.get_ui().collapse {
-                        to_pos[1] -= k as f64 -1. +socket_offset;
+                        to_pos[1] -= *from_count as f64 * socket_offset;
                     }
                     to_pos[0] += n2.get_ui().width/2.;
                     
                     Line::abs(from_pos, to_pos)
-                        .set(id+line_id*k, ui);
+                        .set(WidgetId(id*line_id*k*40), ui);
                 }
             }
         }
@@ -185,31 +193,34 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
 
-            let id = nui.get_id().0 * 20; //allot 20 spaces per node
-            let id = WidgetId(id + 1000); // place in 1k range
+            let id = nui.get_id().0 * 100;
 
             let mut from_pos = *n.get_position();
-            if !nui.collapse {
-                from_pos[1] -= j as f64+socket_offset;
-            }
             from_pos[0] -= nui.width/2.;
             
-            Circle::fill_with(10.,color::LIGHT_BLUE)
-                .xy(from_pos)
-                .set(id+socket_id_out, ui);
-            
+
             for (k,en) in ev.iter().enumerate() {
                 let k = k + 1;
+                let from_count = sockets_from.get(en).unwrap();
+
+                if !nui.collapse {
+                    from_pos[1] -= (j + k) as f64+socket_offset;
+                }
+
+                Circle::fill_with(socket_size,color::LIGHT_BLUE)
+                    .xy(from_pos)
+                    .set(WidgetId(id*socket_id_out*(j+k)*10), ui);
+                
                 if let Some(n2) = self.get_node(&en) {
                     let mut to_pos = *n2.get_position();
                     if !n2.get_ui().collapse {
-                        to_pos[1] -= k as f64 -1. +socket_offset;
+                        to_pos[1] -= *from_count as f64 * socket_offset;
                     }
                     to_pos[0] += n2.get_ui().width/2.;
                     
-                    Circle::fill_with(10.,color::ORANGE)
+                    Circle::fill_with(socket_size,color::ORANGE)
                         .xy(to_pos)
-                        .set(id+socket_id_in*k, ui);
+                        .set(WidgetId(id*socket_id_in*(j+k)*20), ui);
                 }
             }
         }

--- a/src/uigraph.rs
+++ b/src/uigraph.rs
@@ -154,7 +154,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
             
-            let id = nui.get_id().0 * ::MAX_NODES;
+            let id = nui.get_id().0 * ::MAX_NODES * (::MAX_CONN_IN+::MAX_CONN_OUT) +1;
 
             let mut from_pos = *n.get_position();
             
@@ -193,7 +193,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
 
-            let id = nui.get_id().0 * ::MAX_NODES;
+            let id = nui.get_id().0 * ::MAX_NODES + 1;
 
             let mut from_pos = *n.get_position();
             from_pos[0] -= nui.width/2.;

--- a/src/uigraph.rs
+++ b/src/uigraph.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 
 pub type Ui = ::conrod::Ui<Glyphs>;
 
-
 pub trait UiNode: GraphNode {
     fn get_ui(&self) -> &UiBase;
     fn get_ui_mut(&mut self) -> &mut UiBase;
@@ -140,10 +139,6 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             }
         });
 
-        let socket_id_out = 1;
-        let line_id = 2;
-        let socket_id_in = 3;
-
         let socket_size = 10.;
         let socket_offset = 3.*socket_size;
         
@@ -154,7 +149,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
             
-            let id = nui.get_id().0 * ::MAX_NODES * (::MAX_CONN_IN+::MAX_CONN_OUT) +1;
+            let id = nui.get_id().0 +10;
 
             let mut from_pos = *n.get_position();
             
@@ -177,7 +172,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                     to_pos[0] += n2.get_ui().width/2.;
                     
                     Line::abs(from_pos, to_pos)
-                        .set(WidgetId(id*line_id*k), ui);
+                        .set(WidgetId((::MAX_CONN*2) + id + k), ui);
                 }
             }
         }
@@ -193,7 +188,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
 
-            let id = nui.get_id().0 * ::MAX_NODES + 1;
+            let id = nui.get_id().0 + 10;
 
             let mut from_pos = *n.get_position();
             from_pos[0] -= nui.width/2.;
@@ -207,9 +202,10 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                     from_pos[1] -= (j + k) as f64+socket_offset;
                 }
 
+                let id = WidgetId(id+j+k);
                 Circle::fill_with(socket_size,color::LIGHT_BLUE)
                     .xy(from_pos)
-                    .set(WidgetId((id+j+k)*socket_id_out), ui);
+                    .set(id, ui);
                 
                 if let Some(n2) = self.get_node(&en) {
                     let mut to_pos = *n2.get_position();
@@ -218,8 +214,8 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                     }
                     to_pos[0] += n2.get_ui().width/2.;
                     
-                    let id2 = n2.get_ui().get_id().0 + ::MAX_NODES + 1;
-                    let id2 = WidgetId((id2+j+k)*socket_id_in + ::MAX_CONN_IN);
+                    let id2 = n2.get_ui().get_id().0 + 10;
+                    let id2 = WidgetId(id2+j+k + ::MAX_CONN);
                     
                     Circle::fill_with(socket_size,color::ORANGE)
                         .xy(to_pos)

--- a/src/uigraph.rs
+++ b/src/uigraph.rs
@@ -218,9 +218,14 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                     }
                     to_pos[0] += n2.get_ui().width/2.;
                     
+                    let id2 = n2.get_ui().get_id().0 + ::MAX_NODES + 1;
+                    let id2 = WidgetId((id2+j+k)*socket_id_in + ::MAX_CONN_IN);
+                    
                     Circle::fill_with(socket_size,color::ORANGE)
                         .xy(to_pos)
-                        .set(WidgetId((id+j+k)*socket_id_in), ui);
+                        .set(id2, ui);
+
+                    println!("{:?}",id2);
                 }
             }
         }

--- a/src/uigraph.rs
+++ b/src/uigraph.rs
@@ -154,7 +154,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
             
-            let id = nui.get_id().0 * 100; //allotment per node
+            let id = nui.get_id().0 * ::MAX_NODES;
 
             let mut from_pos = *n.get_position();
             
@@ -177,7 +177,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                     to_pos[0] += n2.get_ui().width/2.;
                     
                     Line::abs(from_pos, to_pos)
-                        .set(WidgetId(id*line_id*k*40), ui);
+                        .set(WidgetId(id*line_id*k), ui);
                 }
             }
         }
@@ -193,7 +193,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
             let n = self.get_node(&nid).unwrap();
             let nui = n.get_ui();
 
-            let id = nui.get_id().0 * 100;
+            let id = nui.get_id().0 * ::MAX_NODES;
 
             let mut from_pos = *n.get_position();
             from_pos[0] -= nui.width/2.;
@@ -209,7 +209,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
 
                 Circle::fill_with(socket_size,color::LIGHT_BLUE)
                     .xy(from_pos)
-                    .set(WidgetId(id*socket_id_out*(j+k)*10), ui);
+                    .set(WidgetId((id+j+k)*socket_id_out), ui);
                 
                 if let Some(n2) = self.get_node(&en) {
                     let mut to_pos = *n2.get_position();
@@ -220,7 +220,7 @@ impl<E:GraphEdge,N:UiNode> UiGraph for Graph<E,N> {
                     
                     Circle::fill_with(socket_size,color::ORANGE)
                         .xy(to_pos)
-                        .set(WidgetId(id*socket_id_in*(j+k)*20), ui);
+                        .set(WidgetId((id+j+k)*socket_id_in), ui);
                 }
             }
         }


### PR DESCRIPTION
This is rather difficult for me for some reason, it's very time consuming trying to figure out where widget id's belong in terms of other widget id's. I wish this was never exposed in conrod, but perhaps it has to be since it likely saves cache and draw calls where necessary.

Ideally the ids in mush should be as such:
- First block of widget ids is for tool pane and various interface elements
- Node ids, perhaps a block of 1000 total possible nodes in a graph (probably far fewer in reality)
- Either the node ids are each separated by total connection widget ids per node, like say 100; or a third block of ids just for connections/edges of all nodes.
